### PR TITLE
Summary report at the end of test run

### DIFF
--- a/standalone/src/test/java/io/jaegertracing/qe/result/QueryStatus.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/result/QueryStatus.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2018 The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.qe.result;
+
+public class QueryStatus {
+    private String name;
+    private String queryParameters;
+    private long timetaken;
+
+    public QueryStatus(String name, String queryParameters, long timetaken) {
+        this.name = name;
+        this.queryParameters = queryParameters;
+        this.timetaken = timetaken;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getQueryParameters() {
+        return queryParameters;
+    }
+
+    public long getTimetaken() {
+        return timetaken;
+    }
+}

--- a/standalone/src/test/java/io/jaegertracing/qe/result/TestReport.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/result/TestReport.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2018 The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.qe.result;
+
+import java.text.DecimalFormat;
+import java.util.LinkedList;
+import java.util.List;
+
+public class TestReport {
+    private static TestReport _instance = new TestReport();
+
+    private TestReport() {
+
+    }
+
+    public static TestReport getInstance() {
+        return _instance;
+    }
+
+    DecimalFormat decimalFormat = new DecimalFormat("#.000");
+
+    private long spanCountSent = -1;
+    private long spanCountFound = -1;
+
+    private List<QueryStatus> statusList = new LinkedList<>();
+
+    public void updateSpanCount(long sent, long found) {
+        this.spanCountSent = sent;
+        this.spanCountFound = found;
+    }
+
+    public void addQueryStatus(QueryStatus status) {
+        statusList.add(status);
+    }
+
+    public String getStringReport() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("\n\n======================= TEST SUMMARY REPORT =======================\n");
+
+        builder.append("Span count status: \n");
+        builder.append("------------------\n");
+        builder.append("   Sent   : ").append(spanCountSent).append("\n");
+        builder.append("   Found  : ").append(spanCountFound).append("\n");
+        double dropPercentage = 100.0 - (((double) spanCountFound / spanCountSent) * 100.0);
+        builder.append("   Drop % : ").append(decimalFormat.format(dropPercentage)).append("\n");
+        builder.append("------------------\n\n");
+
+        builder.append("Query execution status: \n");
+        builder.append("-----------------------\n");
+        for (QueryStatus status : statusList) {
+            builder.append("   Name       : ").append(status.getName()).append("\n");
+            builder.append("   Timetaken  : ").append(status.getTimetaken()).append("\n");
+            builder.append("   Parameters : ").append(status.getQueryParameters()).append("\n\n");
+        }
+
+        builder.append("=============================== END ===============================\n\n");
+
+        return builder.toString();
+    }
+}

--- a/standalone/src/test/java/io/jaegertracing/qe/tests/TimeQueriesTest.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/tests/TimeQueriesTest.java
@@ -20,6 +20,8 @@ import io.jaegertracing.qe.restclient.SimpleRestClient;
 import io.jaegertracing.qe.restclient.model.Datum;
 import io.jaegertracing.qe.restclient.model.Span;
 import io.jaegertracing.qe.restclient.model.Tag;
+import io.jaegertracing.qe.result.QueryStatus;
+import io.jaegertracing.qe.result.TestReport;
 
 import java.text.NumberFormat;
 import java.time.Duration;
@@ -33,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
@@ -95,6 +98,11 @@ public class TimeQueriesTest {
         testStartTime = Instant.now();
     }
 
+    @After
+    public void teardown() {
+        logger.info("{}", TestReport.getInstance().getStringReport());        
+    }
+    
     @Test
     public void simpleTimedQueryTest() {
         SimpleRestClient simpleRestClient = new SimpleRestClient();
@@ -104,6 +112,7 @@ public class TimeQueriesTest {
         Instant testEndTime = Instant.now();
         long duration = Duration.between(testStartTime, testEndTime).toMillis();
         logger.info("Retrieval of " + traces.size() + " in simpleTimedQueryTest took " + numberFormat.format(duration) + " milliseconds");
+        TestReport.getInstance().addQueryStatus(new QueryStatus("simpleTimedQueryTest", queryParameters.toString(), duration));
     }
 
 
@@ -115,6 +124,7 @@ public class TimeQueriesTest {
         Instant testEndTime = Instant.now();
         long duration = Duration.between(testStartTime, testEndTime).toMillis();
         logger.info("Retrieval of " + limit + " spans in timeGetByServiceNameTest took " + numberFormat.format(duration) + " milliseconds");
+        TestReport.getInstance().addQueryStatus(new QueryStatus("timeGetByServiceNameTest", queryParameters.toString(), duration));
         assertNotNull(traces);
         assertEquals(limit, traces.size());
 
@@ -134,6 +144,7 @@ public class TimeQueriesTest {
         Instant testEndTime = Instant.now();
         long duration = Duration.between(testStartTime, testEndTime).toMillis();
         logger.info("Retrieval of " + limit + " spans in testGetWithOperationName took " + numberFormat.format(duration) + " milliseconds");
+        TestReport.getInstance().addQueryStatus(new QueryStatus("testGetWithOperationName", queryParameters.toString(), duration));
         assertNotNull(traces);
         assertEquals(limit, traces.size());
 
@@ -155,6 +166,7 @@ public class TimeQueriesTest {
         Instant testEndTime = Instant.now();
         long duration = Duration.between(testStartTime, testEndTime).toMillis();
         logger.info("Retrieval of " + limit + " spans in testGetWithOneTag took " + numberFormat.format(duration) + " milliseconds");
+        TestReport.getInstance().addQueryStatus(new QueryStatus("testGetWithOneTag", queryParameters.toString(), duration));
         assertNotNull(traces);
         assertEquals(limit, traces.size());
 
@@ -178,6 +190,7 @@ public class TimeQueriesTest {
         Instant testEndTime = Instant.now();
         long duration = Duration.between(testStartTime, testEndTime).toMillis();
         logger.info("Retrieval of " + limit + " spans in testGetWithTwoTags took " + numberFormat.format(duration) + " milliseconds");
+        TestReport.getInstance().addQueryStatus(new QueryStatus("testGetWithTwoTags", queryParameters.toString(), duration));
         assertNotNull(traces);
         assertEquals(limit, traces.size());
 

--- a/standalone/src/test/java/io/jaegertracing/qe/tests/ValidateTracesTest.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/tests/ValidateTracesTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
+import io.jaegertracing.qe.result.TestReport;
 import io.jaegertracing.qe.tests.util.PodWatcher;
 
 import java.io.IOException;
@@ -105,6 +106,7 @@ public class ValidateTracesTest {
         long countDuration = Duration.between(startTime, countEndTime).toMillis();
         logger.info("Counting " + numberFormat.format(actualTraceCount) + " traces took " + countDuration / 1000 + "." + countDuration % 1000 + " seconds.");
         Files.write(Paths.get("tracesFoundCount.txt"), Long.toString(actualTraceCount).getBytes(), StandardOpenOption.CREATE);
+        TestReport.getInstance().updateSpanCount(expectedTraceCount.longValue(), actualTraceCount);
         assertEquals("Did not find expected number of traces", expectedTraceCount.intValue(), actualTraceCount);
     }
 


### PR DESCRIPTION
Resolves #26 

Sample report:
```

======================= TEST SUMMARY REPORT =======================
Span count status: 
------------------
   Sent   : 35360
   Found  : 35000
   Drop % : 1.0181
------------------

Query execution status: 
-----------------------
   Name       : simpleTimedQueryTest
   Timetaken  : 251
   Parameters : {service=[standalone], limit=[1]}

   Name       : testGetWithOneTag
   Timetaken  : 11266
   Parameters : {service=[standalone], limit=[100], tag=[iteration:1]}

   Name       : testGetWithOperationName
   Timetaken  : 88
   Parameters : {service=[standalone], limit=[100], operation=[Thread13]}

   Name       : testGetWithTwoTags
   Timetaken  : 11069
   Parameters : {service=[standalone], limit=[100], tag=[iteration:1, podname:earth]}

   Name       : timeGetByServiceNameTest
   Timetaken  : 3836
   Parameters : {service=[standalone], limit=[10000]}

=============================== END ===============================

```