### PR TITLE
Add summary report, client update to 0.30.2 and minor fix in Jenkins pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,9 @@
         <dependencies>
             <dependency>
                 <groupId>io.jaegertracing</groupId>
-                <artifactId>jaeger-core</artifactId>
+                <artifactId>jaeger-client</artifactId>
                 <version>${jaeger.version}</version>
             </dependency>
-            <dependency>
-            	<groupId>io.jaegertracing</groupId>
-            	<artifactId>jaeger-thrift</artifactId>
-            	<version>${jaeger.version}</version>
-        	</dependency>
             <dependency>
                 <groupId>com.datastax.cassandra</groupId>
                 <artifactId>cassandra-driver-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <fabric8.openshift.client.version>3.1.12</fabric8.openshift.client.version>
         <glassfish.jersey.client.version>2.27</glassfish.jersey.client.version>
         <jackson.version>2.9.5</jackson.version>
-        <jaeger.version>0.29.0</jaeger.version>
+        <jaeger.version>0.30.2</jaeger.version>
         <javax.ws.rs.version>2.1</javax.ws.rs.version>
         <junit.version>4.12</junit.version>
         <log4j.version>1.2.17</log4j.version>
@@ -61,6 +61,11 @@
                 <artifactId>jaeger-core</artifactId>
                 <version>${jaeger.version}</version>
             </dependency>
+            <dependency>
+            	<groupId>io.jaegertracing</groupId>
+            	<artifactId>jaeger-thrift</artifactId>
+            	<version>${jaeger.version}</version>
+        	</dependency>
             <dependency>
                 <groupId>com.datastax.cassandra</groupId>
                 <artifactId>cassandra-driver-core</artifactId>

--- a/standalone/Jenkinsfile
+++ b/standalone/Jenkinsfile
@@ -152,7 +152,7 @@ pipeline {
                     oc logs -f elasticsearch-1 > es1.txt &
                     oc logs -f elasticsearch-2 > es2.txt &
                     cd standalone
-                    mvn --activate-profiles openshift clean install fabric8:deploy -Djaeger.agent.image=${JAEGER_AGENT_IMAGE} -Dtracers.per.pod=${TRACERS_PER_POD} -Dpod.count=${WORKER_PODS} -Dduration.in.minutes=${DURATION_IN_MINUTES} -Ddelay=${DELAY} -Djaeger.sampling.rate=${JAEGER_SAMPLING_RATE} -Djaeger.agent.host=${JAEGER_AGENT_HOST} -Duser.agent.or.collector=${USE_AGENT_OR_COLLECTOR} -Djaeger.collector.port=${JAEGER_COLLECTOR_PORT} -Djaeger.collector.host=${JAEGER_COLLECTOR_HOST}
+                    mvn --activate-profiles openshift clean install fabric8:deploy -Djaeger.agent.image=${JAEGER_AGENT_IMAGE} -Dtracers.per.pod=${TRACERS_PER_POD} -Dpod.count=${WORKER_PODS} -Dduration.in.minutes=${DURATION_IN_MINUTES} -Dthread.count=${THREAD_COUNT} -Ddelay=${DELAY} -Djaeger.sampling.rate=${JAEGER_SAMPLING_RATE} -Djaeger.agent.host=${JAEGER_AGENT_HOST} -Duse.agent.or.collector=${USE_AGENT_OR_COLLECTOR} -Djaeger.collector.port=${JAEGER_COLLECTOR_PORT} -Djaeger.collector.host=${JAEGER_COLLECTOR_HOST}
                     mvn --activate-profiles validate clean verify
                 '''
             }

--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -64,12 +64,8 @@
         </dependency>
         <dependency>
             <groupId>io.jaegertracing</groupId>
-            <artifactId>jaeger-core</artifactId>
+            <artifactId>jaeger-client</artifactId>
         </dependency>
-        <dependency>
-        	<groupId>io.jaegertracing</groupId>
-        	<artifactId>jaeger-thrift</artifactId>
-    	</dependency>
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>

--- a/standalone/pom.xml
+++ b/standalone/pom.xml
@@ -67,6 +67,10 @@
             <artifactId>jaeger-core</artifactId>
         </dependency>
         <dependency>
+        	<groupId>io.jaegertracing</groupId>
+        	<artifactId>jaeger-thrift</artifactId>
+    	</dependency>
+        <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
         </dependency>

--- a/standalone/src/main/java/io/jaegertracing/qe/CreateTraces.java
+++ b/standalone/src/main/java/io/jaegertracing/qe/CreateTraces.java
@@ -106,7 +106,7 @@ public class CreateTraces {
             compositeReporter = new CompositeReporter(remoteReporter);
         }
 
-        Sampler sampler = new ProbabilisticSampler(1.0);
+        Sampler sampler = new ProbabilisticSampler(JAEGER_SAMPLING_RATE);
         tracer = new JaegerTracer.Builder(TEST_SERVICE_NAME)
                 .withReporter(compositeReporter)
                 .withSampler(sampler)

--- a/standalone/src/main/java/io/jaegertracing/qe/CreateTraces.java
+++ b/standalone/src/main/java/io/jaegertracing/qe/CreateTraces.java
@@ -46,21 +46,21 @@ import org.slf4j.LoggerFactory;
 public class CreateTraces {
     private static final Map<String, String> envs = System.getenv();
 
-    private static final Integer DELAY = new Integer(envs.getOrDefault("DELAY", "1"));
-    private static final Integer DURATION_IN_MINUTES = new Integer(envs.getOrDefault("DURATION_IN_MINUTES", "5"));
-    private static final String JAEGER_AGENT_HOST = envs.getOrDefault("JAEGER_AGENT_HOST", "localhost");
-    private static final String JAEGER_COLLECTOR_HOST = envs.getOrDefault("JAEGER_COLLECTOR_HOST", "localhost");
-    private static final String JAEGER_COLLECTOR_PORT = envs.getOrDefault("MY_JAEGER_COLLECTOR_PORT", "14268");
-    private static final Integer JAEGER_FLUSH_INTERVAL = new Integer(envs.getOrDefault("JAEGER_FLUSH_INTERVAL", "100"));
-    private static final Integer JAEGER_MAX_PACKET_SIZE = new Integer(envs.getOrDefault("JAEGER_MAX_PACKET_SIZE", "0"));
-    private static final Integer JAEGER_MAX_QUEUE_SIZE = new Integer(envs.getOrDefault("JAEGER_MAX_QUEUE_SIZE", "100000"));
-    private static final Double JAEGER_SAMPLING_RATE = new Double(envs.getOrDefault("JAEGER_SAMPLING_RATE", "1.0"));
-    private static final Integer JAEGER_UDP_PORT = new Integer(envs.getOrDefault("JAEGER_UDP_PORT", "6831"));
-    private static final String TEST_SERVICE_NAME = envs.getOrDefault("TEST_SERVICE_NAME", "standalone");
-    private static final Integer THREAD_COUNT = new Integer(envs.getOrDefault("THREAD_COUNT", "100"));
-    private static final Integer TRACERS_PER_POD = new Integer(envs.getOrDefault("TRACERS_PER_POD", "1"));
-    private static final String USE_AGENT_OR_COLLECTOR = envs.getOrDefault("USE_AGENT_OR_COLLECTOR", "COLLECTOR");
-    private static final String USE_LOGGING_REPORTER = envs.getOrDefault("USE_LOGGING_REPORTER", "false");
+    public static final Integer DELAY = new Integer(envs.getOrDefault("DELAY", "1"));
+    public static final Integer DURATION_IN_MINUTES = new Integer(envs.getOrDefault("DURATION_IN_MINUTES", "5"));
+    public static final String JAEGER_AGENT_HOST = envs.getOrDefault("JAEGER_AGENT_HOST", "localhost");
+    public static final String JAEGER_COLLECTOR_HOST = envs.getOrDefault("JAEGER_COLLECTOR_HOST", "localhost");
+    public static final String JAEGER_COLLECTOR_PORT = envs.getOrDefault("MY_JAEGER_COLLECTOR_PORT", "14268");
+    public static final Integer JAEGER_FLUSH_INTERVAL = new Integer(envs.getOrDefault("JAEGER_FLUSH_INTERVAL", "100"));
+    public static final Integer JAEGER_MAX_PACKET_SIZE = new Integer(envs.getOrDefault("JAEGER_MAX_PACKET_SIZE", "0"));
+    public static final Integer JAEGER_MAX_QUEUE_SIZE = new Integer(envs.getOrDefault("JAEGER_MAX_QUEUE_SIZE", "100000"));
+    public static final Double JAEGER_SAMPLING_RATE = new Double(envs.getOrDefault("JAEGER_SAMPLING_RATE", "1.0"));
+    public static final Integer JAEGER_UDP_PORT = new Integer(envs.getOrDefault("JAEGER_UDP_PORT", "6831"));
+    public static final String TEST_SERVICE_NAME = envs.getOrDefault("TEST_SERVICE_NAME", "standalone");
+    public static final Integer THREAD_COUNT = new Integer(envs.getOrDefault("THREAD_COUNT", "100"));
+    public static final Integer TRACERS_PER_POD = new Integer(envs.getOrDefault("TRACERS_PER_POD", "1"));
+    public static final String USE_AGENT_OR_COLLECTOR = envs.getOrDefault("USE_AGENT_OR_COLLECTOR", "COLLECTOR");
+    public static final String USE_LOGGING_REPORTER = envs.getOrDefault("USE_LOGGING_REPORTER", "false");
 
     public static final String TRACES_CREATED_MESSAGE = "TRACES_CREATED: ";
 

--- a/standalone/src/test/java/io/jaegertracing/qe/result/QueryStatus.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/result/QueryStatus.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2018 The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.qe.result;
+
+public class QueryStatus {
+    private String name;
+    private String queryParameters;
+    private long timetaken;
+
+    public QueryStatus(String name, String queryParameters, long timetaken) {
+        this.name = name;
+        this.queryParameters = queryParameters;
+        this.timetaken = timetaken;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getQueryParameters() {
+        return queryParameters;
+    }
+
+    public long getTimetaken() {
+        return timetaken;
+    }
+}

--- a/standalone/src/test/java/io/jaegertracing/qe/result/TestReport.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/result/TestReport.java
@@ -54,7 +54,7 @@ public class TestReport {
 
     public String getStringReport() {
         StringBuilder builder = new StringBuilder();
-        builder.append("\n\n======================= TEST SUMMARY REPORT =======================\n");
+        builder.append("\n\n========================= TEST SUMMARY REPORT =========================\n");
 
         builder.append("Test configuration: \n");
         builder.append("-----------------------------------------------------------------------\n");
@@ -62,7 +62,6 @@ public class TestReport {
                 .append(timetaken(CreateTraces.DURATION_IN_MINUTES * 1000 * 60)).append("\n");
         builder.append("   Thread count            : ").append(CreateTraces.THREAD_COUNT).append("\n");
         builder.append("   Delay b/w span creation : ").append(CreateTraces.DELAY).append(" ms\n");
-        builder.append("   Span sent to            : ").append(CreateTraces.USE_AGENT_OR_COLLECTOR).append("\n");
         builder.append("   Workers pod count       : ").append(envs.get("WORKER_PODS")).append("\n");
         builder.append("   Tracers per pod         : ").append(CreateTraces.TRACERS_PER_POD).append("\n");
         builder.append("   Collector pod count     : ").append(envs.get("COLLECTOR_PODS")).append("\n");
@@ -91,6 +90,7 @@ public class TestReport {
 
         builder.append("Span count status: \n");
         builder.append("-----------------------------------------------------------------------\n");
+        builder.append("   Spans sent to    : ").append(CreateTraces.USE_AGENT_OR_COLLECTOR).append("\n");
         builder.append("   Spans per second : ").append(spansPersecond).append(" (aprox)\n");
         builder.append("   Spans per minute : ").append(spansPersecond * 60).append(" (aprox)\n");
         builder.append("   Sent             : ").append(spanCountSent).append("\n");
@@ -106,7 +106,7 @@ public class TestReport {
             builder.append("   Parameters : ").append(status.getQueryParameters()).append("\n\n");
         }
 
-        builder.append("=============================== END ===============================\n\n");
+        builder.append("================================= END =================================\n\n");
 
         return builder.toString();
     }

--- a/standalone/src/test/java/io/jaegertracing/qe/result/TestReport.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/result/TestReport.java
@@ -85,17 +85,17 @@ public class TestReport {
         builder.append("-----------------------------------------------------------------------\n\n");
 
         final double dropPercentage = 100.0 - (((double) spanCountFound / spanCountSent) * 100.0);
-        final int spansPersecond = ((int) CreateTraces.THREAD_COUNT * (1000 / CreateTraces.DELAY))
+        final int tracesPersecond = ((int) CreateTraces.THREAD_COUNT * (1000 / CreateTraces.DELAY))
                 * new Integer(envs.getOrDefault("WORKER_PODS", "1"));
 
         builder.append("Span count status: \n");
         builder.append("-----------------------------------------------------------------------\n");
-        builder.append("   Spans sent to    : ").append(CreateTraces.USE_AGENT_OR_COLLECTOR).append("\n");
-        builder.append("   Spans per second : ").append(spansPersecond).append(" (aprox)\n");
-        builder.append("   Spans per minute : ").append(spansPersecond * 60).append(" (aprox)\n");
-        builder.append("   Sent             : ").append(spanCountSent).append("\n");
-        builder.append("   Found            : ").append(spanCountFound).append("\n");
-        builder.append("   Dropped %        : ").append(decimalFormat.format(dropPercentage)).append("\n");
+        builder.append("   Traces sent to  : ").append(CreateTraces.USE_AGENT_OR_COLLECTOR).append("\n");
+        builder.append("   Traces / second : ").append(tracesPersecond).append(" (aprox)\n");
+        builder.append("   Traces / minute : ").append(tracesPersecond * 60).append(" (aprox)\n");
+        builder.append("   Sent            : ").append(spanCountSent).append("\n");
+        builder.append("   Found           : ").append(spanCountFound).append("\n");
+        builder.append("   Dropped %       : ").append(decimalFormat.format(dropPercentage)).append("\n");
         builder.append("-----------------------------------------------------------------------\n\n");
 
         builder.append("Query execution status: \n");

--- a/standalone/src/test/java/io/jaegertracing/qe/result/TestReport.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/result/TestReport.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2018 The Jaeger Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.jaegertracing.qe.result;
+
+import java.text.DecimalFormat;
+import java.util.LinkedList;
+import java.util.List;
+
+public class TestReport {
+    private static TestReport _instance = new TestReport();
+
+    private TestReport() {
+
+    }
+
+    public static TestReport getInstance() {
+        return _instance;
+    }
+
+    DecimalFormat decimalFormat = new DecimalFormat("#.000");
+
+    private long spanCountSent = -1;
+    private long spanCountFound = -1;
+
+    private List<QueryStatus> statusList = new LinkedList<>();
+
+    public void updateSpanCount(long sent, long found) {
+        this.spanCountSent = sent;
+        this.spanCountFound = found;
+    }
+
+    public void addQueryStatus(QueryStatus status) {
+        statusList.add(status);
+    }
+
+    public String getStringReport() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("\n\n======================= TEST SUMMARY REPORT =======================\n");
+
+        builder.append("Span count status: \n");
+        builder.append("------------------\n");
+        builder.append("   Sent   : ").append(spanCountSent).append("\n");
+        builder.append("   Found  : ").append(spanCountFound).append("\n");
+        double dropPercentage = 100.0 - (((double) spanCountFound / spanCountSent) * 100.0);
+        builder.append("   Drop % : ").append(decimalFormat.format(dropPercentage)).append("\n");
+        builder.append("------------------\n\n");
+
+        builder.append("Query execution status: \n");
+        builder.append("-----------------------\n");
+        for (QueryStatus status : statusList) {
+            builder.append("   Name       : ").append(status.getName()).append("\n");
+            builder.append("   Timetaken  : ").append(status.getTimetaken()).append("\n");
+            builder.append("   Parameters : ").append(status.getQueryParameters()).append("\n\n");
+        }
+
+        builder.append("=============================== END ===============================\n\n");
+
+        return builder.toString();
+    }
+}

--- a/standalone/src/test/java/io/jaegertracing/qe/result/TestReport.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/result/TestReport.java
@@ -57,7 +57,7 @@ public class TestReport {
         builder.append("\n\n======================= TEST SUMMARY REPORT =======================\n");
 
         builder.append("Test configuration: \n");
-        builder.append("------------------------------------------------------------\n");
+        builder.append("-----------------------------------------------------------------------\n");
         builder.append("   Test duration           : ")
                 .append(timetaken(CreateTraces.DURATION_IN_MINUTES * 1000 * 60)).append("\n");
         builder.append("   Thread count            : ").append(CreateTraces.THREAD_COUNT).append("\n");
@@ -83,23 +83,23 @@ public class TestReport {
         builder.append("   Collector image         : ").append(envs.get("JAEGER_COLLECTOR_IMAGE")).append("\n");
         builder.append("   Query image             : ").append(envs.get("JAEGER_QUERY_IMAGE")).append("\n");
 
-        builder.append("------------------------------------------------------------\n\n");
+        builder.append("-----------------------------------------------------------------------\n\n");
 
         final double dropPercentage = 100.0 - (((double) spanCountFound / spanCountSent) * 100.0);
         final int spansPersecond = ((int) CreateTraces.THREAD_COUNT * (1000 / CreateTraces.DELAY))
                 * new Integer(envs.getOrDefault("WORKER_PODS", "1"));
 
         builder.append("Span count status: \n");
-        builder.append("--------------------------------------------------\n");
+        builder.append("-----------------------------------------------------------------------\n");
         builder.append("   Spans per second : ").append(spansPersecond).append(" (aprox)\n");
         builder.append("   Spans per minute : ").append(spansPersecond * 60).append(" (aprox)\n");
         builder.append("   Sent             : ").append(spanCountSent).append("\n");
         builder.append("   Found            : ").append(spanCountFound).append("\n");
         builder.append("   Dropped %        : ").append(decimalFormat.format(dropPercentage)).append("\n");
-        builder.append("--------------------------------------------------\n\n");
+        builder.append("-----------------------------------------------------------------------\n\n");
 
         builder.append("Query execution status: \n");
-        builder.append("-----------------------\n");
+        builder.append("-----------------------------------------------------------------------\n");
         for (QueryStatus status : statusList) {
             builder.append("   Name       : ").append(status.getName()).append("\n");
             builder.append("   Timetaken  : ").append(timetaken(status.getTimetaken())).append("\n");

--- a/standalone/src/test/java/io/jaegertracing/qe/tests/TimeQueriesTest.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/tests/TimeQueriesTest.java
@@ -20,6 +20,8 @@ import io.jaegertracing.qe.restclient.SimpleRestClient;
 import io.jaegertracing.qe.restclient.model.Datum;
 import io.jaegertracing.qe.restclient.model.Span;
 import io.jaegertracing.qe.restclient.model.Tag;
+import io.jaegertracing.qe.result.QueryStatus;
+import io.jaegertracing.qe.result.TestReport;
 
 import java.text.NumberFormat;
 import java.time.Duration;
@@ -33,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
@@ -95,6 +98,11 @@ public class TimeQueriesTest {
         testStartTime = Instant.now();
     }
 
+    @After
+    public void teardown() {
+        logger.info("{}", TestReport.getInstance().getStringReport());        
+    }
+    
     @Test
     public void simpleTimedQueryTest() {
         SimpleRestClient simpleRestClient = new SimpleRestClient();
@@ -104,6 +112,7 @@ public class TimeQueriesTest {
         Instant testEndTime = Instant.now();
         long duration = Duration.between(testStartTime, testEndTime).toMillis();
         logger.info("Retrieval of " + traces.size() + " in simpleTimedQueryTest took " + numberFormat.format(duration) + " milliseconds");
+        TestReport.getInstance().addQueryStatus(new QueryStatus("simpleTimedQueryTest", queryParameters.toString(), duration));
     }
 
 
@@ -115,6 +124,7 @@ public class TimeQueriesTest {
         Instant testEndTime = Instant.now();
         long duration = Duration.between(testStartTime, testEndTime).toMillis();
         logger.info("Retrieval of " + limit + " spans in timeGetByServiceNameTest took " + numberFormat.format(duration) + " milliseconds");
+        TestReport.getInstance().addQueryStatus(new QueryStatus("timeGetByServiceNameTest", queryParameters.toString(), duration));
         assertNotNull(traces);
         assertEquals(limit, traces.size());
 
@@ -134,6 +144,7 @@ public class TimeQueriesTest {
         Instant testEndTime = Instant.now();
         long duration = Duration.between(testStartTime, testEndTime).toMillis();
         logger.info("Retrieval of " + limit + " spans in testGetWithOperationName took " + numberFormat.format(duration) + " milliseconds");
+        TestReport.getInstance().addQueryStatus(new QueryStatus("testGetWithOperationName", queryParameters.toString(), duration));
         assertNotNull(traces);
         assertEquals(limit, traces.size());
 
@@ -155,6 +166,7 @@ public class TimeQueriesTest {
         Instant testEndTime = Instant.now();
         long duration = Duration.between(testStartTime, testEndTime).toMillis();
         logger.info("Retrieval of " + limit + " spans in testGetWithOneTag took " + numberFormat.format(duration) + " milliseconds");
+        TestReport.getInstance().addQueryStatus(new QueryStatus("testGetWithOneTag", queryParameters.toString(), duration));
         assertNotNull(traces);
         assertEquals(limit, traces.size());
 
@@ -178,6 +190,7 @@ public class TimeQueriesTest {
         Instant testEndTime = Instant.now();
         long duration = Duration.between(testStartTime, testEndTime).toMillis();
         logger.info("Retrieval of " + limit + " spans in testGetWithTwoTags took " + numberFormat.format(duration) + " milliseconds");
+        TestReport.getInstance().addQueryStatus(new QueryStatus("testGetWithTwoTags", queryParameters.toString(), duration));
         assertNotNull(traces);
         assertEquals(limit, traces.size());
 

--- a/standalone/src/test/java/io/jaegertracing/qe/tests/TimeQueriesTest.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/tests/TimeQueriesTest.java
@@ -99,7 +99,7 @@ public class TimeQueriesTest {
     }
 
     @AfterClass
-    public void teardown() {
+    public static void teardown() {
         logger.info("{}", TestReport.getInstance().getStringReport());        
     }
     

--- a/standalone/src/test/java/io/jaegertracing/qe/tests/TimeQueriesTest.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/tests/TimeQueriesTest.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
@@ -98,7 +98,7 @@ public class TimeQueriesTest {
         testStartTime = Instant.now();
     }
 
-    @After
+    @AfterClass
     public void teardown() {
         logger.info("{}", TestReport.getInstance().getStringReport());        
     }

--- a/standalone/src/test/java/io/jaegertracing/qe/tests/ValidateTracesTest.java
+++ b/standalone/src/test/java/io/jaegertracing/qe/tests/ValidateTracesTest.java
@@ -28,6 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
+import io.jaegertracing.qe.result.TestReport;
 import io.jaegertracing.qe.tests.util.PodWatcher;
 
 import java.io.IOException;
@@ -105,6 +106,7 @@ public class ValidateTracesTest {
         long countDuration = Duration.between(startTime, countEndTime).toMillis();
         logger.info("Counting " + numberFormat.format(actualTraceCount) + " traces took " + countDuration / 1000 + "." + countDuration % 1000 + " seconds.");
         Files.write(Paths.get("tracesFoundCount.txt"), Long.toString(actualTraceCount).getBytes(), StandardOpenOption.CREATE);
+        TestReport.getInstance().updateSpanCount(expectedTraceCount.longValue(), actualTraceCount);
         assertEquals("Did not find expected number of traces", expectedTraceCount.intValue(), actualTraceCount);
     }
 


### PR DESCRIPTION
Resolves: https://github.com/jaegertracing/jaeger-performance/issues/26
* Summary report added
* Switched jaegertracing client to `0.30.2`.
* Minor fixes in Jenkins pipeline file.


```
========================= TEST SUMMARY REPORT =========================
Test configuration: 
-----------------------------------------------------------------------
   Test duration           : 0:05:00.000
   Thread count            : 5
   Delay b/w span creation : 10 ms
   Workers pod count       : 1
   Tracers per pod         : 1
   Collector pod count     : 2
   Collector queue size    : 3000000
   Storage type            : elasticsearch
   ES memory               : 1Gi
   ES bulk size            : 10000000
   ES bulk workers         : 10
   ES bulk flush interval  : 1s
   Jaeger sampling rate    : 1.0
   Jaeger flush interval   : 100 ms
   Jaeger max queue size   : 100000
   Collector host          : jaeger-collector:14268
   Agent host(UDP)         : localhost:6831
   Agent image             : jaegertracing/jaeger-agent:1.6
   Collector image         : jaegertracing\/jaeger-collector:1.6
   Query image             : jaegertracing\/jaeger-query:1.6
-----------------------------------------------------------------------

Span count status: 
-----------------------------------------------------------------------
   Traces sent to  : AGENT
   Traces / second : 500 (aprox)
   Traces / minute : 30000 (aprox)
   Sent            : 147136
   Found           : 147136
   Dropped %       : 0.000
-----------------------------------------------------------------------

Query execution status: 
-----------------------------------------------------------------------
   Name       : simpleTimedQueryTest
   Timetaken  : 0:00:00.155
   Parameters : {service=[standalone], limit=[1]}

   Name       : testGetWithOneTag
   Timetaken  : 0:00:10.815
   Parameters : {service=[standalone], limit=[100], tag=[iteration:1]}

   Name       : testGetWithOperationName
   Timetaken  : 0:00:00.257
   Parameters : {service=[standalone], limit=[100], operation=[Thread3]}

   Name       : testGetWithTwoTags
   Timetaken  : 0:00:00.149
   Parameters : {service=[standalone], limit=[5], tag=[iteration:1, podname:9tfqv]}

   Name       : timeGetByServiceNameTest
   Timetaken  : 0:00:09.297
   Parameters : {service=[standalone], limit=[10000]}

================================= END =================================

```